### PR TITLE
Puts "display_name" back.

### DIFF
--- a/services/config.rb
+++ b/services/config.rb
@@ -5,6 +5,7 @@ coreo_aws_advisor_alert "ec2-ip-address-whitelisted" do
   action :define
   service :ec2
   link "http://kb.cloudcoreo.com/mydoc_ec2-ip-address-whitelisted.html"
+  display_name "Security Group contains IP address"
   description "Security Group contains IP address"
   category "Security"
   suggested_action "Review Security Group to ensure that the host ip address added is to allowed access."
@@ -19,6 +20,7 @@ coreo_aws_advisor_alert "ec2-unrestricted-traffic" do
   action :define
   service :ec2
   link "http://kb.cloudcoreo.com/mydoc_ec2-unrestricted-traffic.html"
+  display_name "Security group allows unrestricted traffic"
   description "All IP addresses are allowed to access resources in a specific security group."
   category "Security"
   suggested_action "Restrict access to the minimum specific set of IP address or ports necessary."
@@ -33,6 +35,7 @@ coreo_aws_advisor_alert "ec2-TCP-1521-0.0.0.0/0" do
   action :define
   service :ec2
   link "http://kb.cloudcoreo.com/mydoc_ec2-tcpportopen.html"
+  display_name "TCP port is open - 1521"
   description "Important TCP port is open and/or open to the world."
   category "Security"
   suggested_action "Only open those ports that must be open for your service to operate. Consider deleting or modifying the affected security group."
@@ -47,6 +50,7 @@ coreo_aws_advisor_alert "ec2-TCP-3306-0.0.0.0/0" do
   action :define
   service :ec2
   link "http://kb.cloudcoreo.com/mydoc_ec2-tcpportopen.html"
+  display_name "TCP port is open - 3306"
   description "Important TCP port is open and/or open to the world."
   category "Security"
   suggested_action "Only open those ports that must be open for your service to operate. Consider deleting or modifying the affected security group."
@@ -61,6 +65,7 @@ coreo_aws_advisor_alert "ec2-TCP-5432-0.0.0.0/0" do
   action :define
   service :ec2
   link "http://kb.cloudcoreo.com/mydoc_ec2-tcpportopen.html"
+  display_name "TCP port is open - 5432"
   description "Important TCP port is open and/or open to the world."
   category "Security"
   suggested_action "Only open those ports that must be open for your service to operate. Consider deleting or modifying the affected security group."
@@ -75,6 +80,7 @@ coreo_aws_advisor_alert "ec2-TCP-27017-0.0.0.0/0" do
   action :define
   service :ec2
   link "http://kb.cloudcoreo.com/mydoc_ec2-tcpportopen.html"
+  display_name "TCP port is open - 27017"
   description "Important TCP port is open and/or open to the world."
   category "Security"
   suggested_action "Only open those ports that must be open for your service to operate. Consider deleting or modifying the affected security group."
@@ -89,6 +95,7 @@ coreo_aws_advisor_alert "ec2-TCP-1433-0.0.0.0/0" do
   action :define
   service :ec2
   link "http://kb.cloudcoreo.com/mydoc_ec2-tcpportopen.html"
+  display_name "TCP port is open - 1433"
   description "Important TCP port is open and/or open to the world."
   category "Security"
   suggested_action "Only open those ports that must be open for your service to operate. Consider deleting or modifying the affected security group."
@@ -103,6 +110,7 @@ coreo_aws_advisor_alert "ec2-TCP-3389-0.0.0.0/0" do
   action :define
   service :ec2
   link "http://kb.cloudcoreo.com/mydoc_ec2-tcpportopen.html"
+  display_name "TCP port is open - 3389"
   description "Important TCP port is open and/or open to the world."
   category "Security"
   suggested_action "Only open those ports that must be open for your service to operate. Consider deleting or modifying the affected security group."
@@ -117,6 +125,7 @@ coreo_aws_advisor_alert "ec2-TCP-22-0.0.0.0/0" do
   action :define
   service :ec2
   link "http://kb.cloudcoreo.com/mydoc_ec2-tcpportopen.html"
+  display_name "TCP port is open - 22"
   description "Important TCP port is open and/or open to the world."
   category "Security"
   suggested_action "Only open those ports that must be open for your service to operate. Consider deleting or modifying the affected security group."
@@ -131,6 +140,7 @@ coreo_aws_advisor_alert "ec2-TCP-5439-0.0.0.0/0" do
   action :define
   service :ec2
   link "http://kb.cloudcoreo.com/mydoc_ec2-tcpportopen.html"
+  display_name "TCP port is open - 5439"
   description "Important TCP port is open and/or open to the world."
   category "Security"
   suggested_action "Only open those ports that must be open for your service to operate. Consider deleting or modifying the affected security group."
@@ -145,6 +155,7 @@ coreo_aws_advisor_alert "ec2-TCP-23" do
   action :define
   service :ec2
   link "http://kb.cloudcoreo.com/mydoc_ec2-tcpportopen.html"
+  display_name "TCP port is open - 23"
   description "Important TCP port is open and/or open to the world."
   category "Security"
   suggested_action "Only open those ports that must be open for your service to operate. Consider deleting or modifying the affected security group."
@@ -159,6 +170,7 @@ coreo_aws_advisor_alert "ec2-TCP-21" do
   action :define
   service :ec2
   link "http://kb.cloudcoreo.com/mydoc_ec2-tcpportopen.html"
+  display_name "TCP port is open - 21"
   description "Important TCP port is open and/or open to the world."
   category "Security"
   suggested_action "Only open those ports that must be open for your service to operate. Consider deleting or modifying the affected security group."
@@ -173,6 +185,7 @@ coreo_aws_advisor_alert "ec2-TCP-20" do
   action :define
   service :ec2
   link "http://kb.cloudcoreo.com/mydoc_ec2-tcpportopen.html"
+  display_name "TCP port is open - 20"
   description "Important TCP port is open and/or open to the world."
   category "Security"
   suggested_action "Only open those ports that must be open for your service to operate. Consider deleting or modifying the affected security group."
@@ -187,6 +200,7 @@ coreo_aws_advisor_alert "ec2-ports-range" do
   action :define
   service :ec2
   link "http://kb.cloudcoreo.com/mydoc_ec2-ports-range.html"
+  display_name "Security group contains a port range"
   description "Security group contains a port range rather than individual ports."
   category "Security"
   suggested_action "Only add rules to your Security group that specify individual ports and don't use port ranges unless they are required."


### PR DESCRIPTION
This change puts “display_name” back in when we are ready for it. I am trying this way by reversing my commit where I took “display_name” out.
This reverts commit 4adb52cdaf20eafb9e8afb498aa5f90718974def, reversing
changes made to fea57f3c1ee73d7309145fcf81ebf70fe13d324f.