### PR TITLE
remove unnecessary var and set global var (table.yaml) and (JSONwithS…

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -46,11 +46,6 @@ variables:
         - us-west-1
         - us-west-2
         - eu-west-1
-  AUDIT_AWS_EC2_ROLLUP_REPORT:
-    description: "Would you like to send a rollup EC2 report? This is a short email that summarizes the number of checks performed and the number of violations found. Options - notify / nothing. Default is nothing."
-    required: true
-    type: string
-    default: "nothing"
   AUDIT_AWS_EC2_OWNER_TAG:
     description: "Enter an AWS tag whose value is an email address of the owner of the EC2 object. (Optional)"
     required: false

--- a/services/config.rb
+++ b/services/config.rb
@@ -505,10 +505,25 @@ const VARIABLES = { NO_OWNER_EMAIL, OWNER_TAG,
 
 const CloudCoreoJSRunner = require('cloudcoreo-jsrunner-commons');
 const AuditEC2 = new CloudCoreoJSRunner(JSON_INPUT, VARIABLES);
+
+const JSONReportAfterGeneratingSuppression = AuditEC2.getJSONForAuditPanel();
+coreoExport('JSONReport', JSON.stringify(JSONReportAfterGeneratingSuppression));
+
 const notifiers = AuditEC2.getNotifiers();
 callback(notifiers);
   EOH
 end
+
+
+
+coreo_uni_util_variables "update-planwide-3" do
+  action :set
+  variables([
+                {'COMPOSITE::coreo_uni_util_variables.planwide.results' => 'COMPOSITE::coreo_uni_util_jsrunner.ec2-tags-to-notifiers-array.JSONReport'},
+                {'COMPOSITE::coreo_uni_util_variables.planwide.table' => 'COMPOSITE::coreo_uni_util_jsrunner.ec2-tags-to-notifiers-array.table'}
+            ])
+end
+
 
 coreo_uni_util_jsrunner "ec2-tags-rollup" do
   action :run


### PR DESCRIPTION
CON-290 Cloudtrail jsrunner error if suppression.yaml file does not exist
CON-303 must provide_composite_access to get to table and suppression yaml
CON-304 remove action vars for audit notifiers
CON-293 implement the var-setters and planwide changes across all audit stacks	
CON-294 decrement violation counts in the suppressions across audit stacks