### PR TITLE
Con 504 flow logs inv

### DIFF
--- a/services/config.rb
+++ b/services/config.rb
@@ -411,9 +411,7 @@ coreo_aws_rule_runner "vpcs-flow-logs-inventory" do
   action (("${AUDIT_AWS_EC2_ALERT_LIST}".include?("ec2-vpc-flow-logs")) ? :run : :nothing)
   service :ec2
   regions ${AUDIT_AWS_EC2_REGIONS}
-# turning off flow-logs-inventory temporarily - there is an error
-  rules ["vpc-inventory", "flow-logs-inventory"]
-  # rules ["vpc-inventory"]
+  rules ["vpc-inventory"]
 end
 
 coreo_uni_util_variables "ec2-planwide" do

--- a/services/config.rb
+++ b/services/config.rb
@@ -412,8 +412,8 @@ coreo_aws_rule_runner "vpcs-flow-logs-inventory" do
   service :ec2
   regions ${AUDIT_AWS_EC2_REGIONS}
 # turning off flow-logs-inventory temporarily - there is an error
-#  rules ["vpc-inventory", "flow-logs-inventory"]
-  rules ["vpc-inventory"]
+  rules ["vpc-inventory", "flow-logs-inventory"]
+  # rules ["vpc-inventory"]
 end
 
 coreo_uni_util_variables "ec2-planwide" do


### PR DESCRIPTION
I'm unable to reproduce error CON-504. Have tried on multiple branches and environments and accounts, after adding vpc flow logs inventory back in.

At the same time, the temporary patch that comments out the flow logs inventory rule has not impeded the ec2 flow logs rule that it exists to support.

The js runner gets the results of the rule even when the rule isn't in the audit list - which I didn't think was the case - so I'll just go ahead and make the temporary path permanent